### PR TITLE
Fix Dasboard cache not refreshing

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -17,7 +17,7 @@ import { dashboardApi } from './services/dashboardApi'
 const persistConfig = {
     key: 'root',
     storage,
-    whitelist: ['dashboardApi'], // elements that will be persisted
+    whitelist: [], // elements that will be persisted
     blacklist: [] // elements that will not be persisted
 }
 


### PR DESCRIPTION
- Remove dashboard api from persist config whitelist