### PR TITLE
Hotfix/fix teams not filtering for table headers

### DIFF
--- a/src/components/DashboardTable/DashboardTable.tsx
+++ b/src/components/DashboardTable/DashboardTable.tsx
@@ -142,13 +142,9 @@ const DashboardTable: FC<DashboardTableProps> = ({
     )
 
     const renderTableRows = useMemo(() => {
-        const filteredTeams = teams.filter((t) => t.problems.length > 0)
-
-        const sortedTeams = filteredTeams.sort((a, b) => b.score - a.score)
-
         const tableRows = []
 
-        for (let index = 0; index < sortedTeams.length; index++) {
+        for (let index = 0; index < teams.length; index++) {
             tableRows.push(
                 <Slide
                     direction="up"
@@ -158,7 +154,7 @@ const DashboardTable: FC<DashboardTableProps> = ({
                     in
                     container={containerRef.current}
                 >
-                    {RenderTableRow(index, sortedTeams[index])}
+                    {RenderTableRow(index, teams[index])}
                 </Slide>
             )
         }

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -16,11 +16,15 @@ import environment from '../../resources/constants/environment'
 const deadline = environment.deadline
 
 const HomePage: FC = () => {
-    const { data, isLoading, refetch } = useGetDashboardQuery(undefined, {
-        refetchOnMountOrArgChange: true,
-        refetchOnReconnect: true,
-        pollingInterval: 30000
-    })
+    const { data, isLoading, refetch, isSuccess } = useGetDashboardQuery(
+        undefined,
+        {
+            refetchOnMountOrArgChange: true,
+            refetchOnReconnect: true,
+            pollingInterval: 30000
+        }
+    )
+
     const [isBriefing, setBriefing] = useState<boolean>(
         window.location.href.endsWith('#briefing')
     )
@@ -52,7 +56,6 @@ const HomePage: FC = () => {
 
         const listener = () => {
             console.log(`UPDATE RECIEVED: ${new Date()}`)
-
             refetch()
         }
 
@@ -62,6 +65,14 @@ const HomePage: FC = () => {
             clearInterval(interval)
         }
     }, [refetch])
+
+    const getFilteredTeams = useMemo(() => {
+        if (!isSuccess || !data) return []
+
+        return data
+            .filter((team) => team.problems.length > 0)
+            .sort((a, b) => b.score - a.score)
+    }, [data, isSuccess])
 
     const renderedBody = useMemo(
         () => (
@@ -79,11 +90,11 @@ const HomePage: FC = () => {
                         <h2>Writing Dashboard...</h2>
                     </div>
                 ) : (
-                    <DashboardTable teams={data} />
+                    <DashboardTable teams={getFilteredTeams} />
                 )}
             </div>
         ),
-        [data, isLoading, isBriefing]
+        [isBriefing, isLoading, getFilteredTeams]
     )
 
     return (


### PR DESCRIPTION
## Problem

When incoming team data starts with a team that has an empty `problems` array, problem table headers would not display.
This happens because the `renderHeaders` function inside the `DashboardTable` component does not use the filtered team array.

## Fix

- Refactored filter and sort of teams array to outside the `DashboardTable` component.
- Team data will first be filtered and sorted in `HomePage` component before being passed on to `DashboardTable`